### PR TITLE
Implementation of UDP visa check before TCP connection

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
 }
 
 int example_client() {
-    auto accept_result = hpws::client::connect ( "hpws", 16*1024*1024, "localhost", 8080, "/", "visa_data", {} );
+    auto accept_result = hpws::client::connect ( "hpws", 16*1024*1024, "localhost", 8080, "/", {}, NULL, false, "visa_token" );
     
     if (std::holds_alternative<hpws::client>(accept_result)) {
         printf("[EXAMPLE.CPP] a client connected\n");
@@ -73,7 +73,7 @@ int example_client() {
 
 
 int example_server() {
-    auto server = hpws::server::create ( "hpws", 16*1024*1024, 8080, 512, 2, "cert.pem", "key.pem", "visa_data", {} );
+    auto server = hpws::server::create ( "hpws", 16*1024*1024, 8080, 512, 2, "cert.pem", "key.pem", {}, NULL, false, "visa_token" );
 
     if ( std::holds_alternative<hpws::server>(server) ) {
         fprintf(stderr, "[EXAMPLE.CPP] we got a server\n");

--- a/example.cpp
+++ b/example.cpp
@@ -48,7 +48,6 @@ int example_client() {
         //client.write("a message from the client\n");
         
         for(;;) {
-            int counter = 0;
             auto read_result = client.read();
             if ( std::holds_alternative<hpws::error>(read_result) ) {
                 PRINT_HPWS_ERROR(read_result);

--- a/example.cpp
+++ b/example.cpp
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
 }
 
 int example_client() {
-    auto accept_result = hpws::client::connect ( "hpws", 16*1024*1024, "localhost", 8080, "/", {} );
+    auto accept_result = hpws::client::connect ( "hpws", 16*1024*1024, "localhost", 8080, "/", true, {} );
     
     if (std::holds_alternative<hpws::client>(accept_result)) {
         printf("[EXAMPLE.CPP] a client connected\n");
@@ -73,7 +73,7 @@ int example_client() {
 
 
 int example_server() {
-    auto server = hpws::server::create ( "hpws", 16*1024*1024, 8080, 512, 2, "cert.pem", "key.pem", {} );
+    auto server = hpws::server::create ( "hpws", 16*1024*1024, 8080, 512, 2, "cert.pem", "key.pem", true, {} );
 
     if ( std::holds_alternative<hpws::server>(server) ) {
         fprintf(stderr, "[EXAMPLE.CPP] we got a server\n");

--- a/example.cpp
+++ b/example.cpp
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
 }
 
 int example_client() {
-    auto accept_result = hpws::client::connect ( "hpws", 16*1024*1024, "localhost", 8080, "/", true, {} );
+    auto accept_result = hpws::client::connect ( "hpws", 16*1024*1024, "localhost", 8080, "/", "visa_data", {} );
     
     if (std::holds_alternative<hpws::client>(accept_result)) {
         printf("[EXAMPLE.CPP] a client connected\n");
@@ -73,7 +73,7 @@ int example_client() {
 
 
 int example_server() {
-    auto server = hpws::server::create ( "hpws", 16*1024*1024, 8080, 512, 2, "cert.pem", "key.pem", true, {} );
+    auto server = hpws::server::create ( "hpws", 16*1024*1024, 8080, 512, 2, "cert.pem", "key.pem", "visa_data", {} );
 
     if ( std::holds_alternative<hpws::server>(server) ) {
         fprintf(stderr, "[EXAMPLE.CPP] we got a server\n");

--- a/example.cpp
+++ b/example.cpp
@@ -48,7 +48,7 @@ int example_client() {
         //client.write("a message from the client\n");
         
         for(;;) {
-
+            int counter = 0;
             auto read_result = client.read();
             if ( std::holds_alternative<hpws::error>(read_result) ) {
                 PRINT_HPWS_ERROR(read_result);
@@ -66,6 +66,10 @@ int example_client() {
             client.ack(s);    
             char out[1024];
             sprintf(out, "message from client: %d\n", ++msgcounter);
+            if(msgcounter>10){
+
+                break;
+            }
             client.write(out);
         }
     }

--- a/hpws.c
+++ b/hpws.c
@@ -2272,10 +2272,10 @@ void calculate_pow(const unsigned char *data, const size_t data_len, unsigned ch
     {
         unsigned char hash_buf[data_len + sizeof(*nonce)];
         memcpy(&hash_buf, data, data_len);
-        memcpy(((unsigned char *)(&hash_buf) + data_len), nonce, sizeof(*nonce));
+        memcpy(&hash_buf[data_len], nonce, sizeof(*nonce));
 
         // Calculate SHA-256 hash
-        SHA256(hash_buf, sizeof(hash_buf), hash);
+        SHA256((unsigned char *)&hash_buf, sizeof(hash_buf), hash);
 
         int i = 0;
         while (i < POW_DIFFICULTY)
@@ -2310,15 +2310,15 @@ bool verify_pow(const unsigned char *hash, const unsigned char *data, const size
 
     unsigned char hash_buf[data_len + sizeof(nonce)];
     memcpy(&hash_buf, data, data_len);
-    memcpy(((unsigned char *)(&hash_buf) + data_len), &nonce, sizeof(nonce));
+    memcpy(&hash_buf[data_len], &nonce, sizeof(nonce));
 
     unsigned char hash_calc[SHA256_DIGEST_LENGTH];
 
     // Calculate SHA-256 hash.
-    SHA256(hash_buf, sizeof(hash_buf), (unsigned char *)&hash_calc);
+    SHA256((unsigned char *)&hash_buf, sizeof(hash_buf), (unsigned char *)&hash_calc);
 
     // Verify hash.
-    if (memcmp((unsigned char *)hash, &hash_calc, sizeof(hash_calc)) == 0)
+    if (memcmp(hash, &hash_calc, sizeof(hash_calc)) == 0)
         return true;
 
     return false;
@@ -2332,9 +2332,9 @@ void generate_challenge(unsigned char *challenge) {
 
     // Combine random number and timestamp into a buffer
     char buffer[sizeof(random_number) + sizeof(current_time)];
-    *(uint32_t *)((unsigned char *)&buffer) = random_number;
-    *(uint32_t *)((unsigned char *)&buffer + sizeof(random_number)) = current_time;
+    *(uint32_t *)&buffer = random_number;
+    *(uint32_t *)&buffer[sizeof(random_number)] = current_time;
 
     // Hash the buffer using SHA-256
-    SHA256((unsigned char *)buffer, sizeof(buffer), challenge);
+    SHA256((unsigned char *)&buffer, sizeof(buffer), challenge);
 }

--- a/hpws.c
+++ b/hpws.c
@@ -559,14 +559,8 @@ int main(int argc, char **argv)
                             {
                                 *(uint8_t *)&visa_msg_buf = UDP_MSG_VISA_RES;
 
-                                if (err_no>0){
-                                    if (err_no == 1)
-                                        *(uint8_t *)((uint8_t *)&visa_msg_buf + 1) = VISA_MSG_EXPIRED;
-                                    else if (err_no == 2)
-                                        *(uint8_t *)((uint8_t *)&visa_msg_buf + 1) = VISA_MSG_TOO_LARGE;
-                                    else if (err_no == 3)
-                                        *(uint8_t *)((uint8_t *)&visa_msg_buf + 1) = VISA_MSG_VERSION_MISMATCHED;
-                                }
+                                if (err_no>0)
+                                    *(uint8_t *)((uint8_t *)&visa_msg_buf + 2) = err_no;
                                 // Check for the proof of work in the received data and send approval or rejection accordingly.
                                 else if (verify_pow(((unsigned char *)&visa_msg_buf + 5), challenge_sent, CHALLENGE_SIZE, *(int *)((unsigned char *)&visa_msg_buf + 37)))
                                 {
@@ -2333,8 +2327,8 @@ void generate_challenge(unsigned char *challenge) {
 
     // Combine random number and timestamp into a buffer
     char buffer[sizeof(random_number) + sizeof(current_time)];
-    memcpy(buffer, &random_number, sizeof(random_number));
-    memcpy(buffer + sizeof(random_number), &current_time, sizeof(current_time));
+    *(uint32_t *)((unsigned char *)&buffer) = random_number;
+    *(uint32_t *)((unsigned char *)&buffer + sizeof(random_number)) = current_time;
 
     // Hash the buffer using SHA-256
     SHA256((unsigned char *)buffer, sizeof(buffer), challenge);

--- a/hpws.c
+++ b/hpws.c
@@ -880,7 +880,7 @@ int main(int argc, char **argv)
                 ABEND(visa_msg_buf[3], "init request rejected from the server");
             }
 
-            memcpy(challenge, ((unsigned char *)&visa_msg_buf + 4), CHALLENGE_SIZE);
+            memcpy(challenge, &visa_msg_buf[4], CHALLENGE_SIZE);
 
             // Create visa request with the pow and send to the server.
             *(uint16_t *)&visa_msg_buf = VISA_MSG_VERSION;

--- a/hpws.c
+++ b/hpws.c
@@ -525,7 +525,7 @@ int main(int argc, char **argv)
                         
                         if (*(int *)((unsigned char *)&visa_msg_buf + 1) <= time(NULL) - VISA_EXPIRY_TIME_SECONDS)
                         {
-                            err_no = 1; // is message is too old
+                            err_no = VISA_MSG_EXPIRED; // is message is too old
                             fprintf(stderr, "Received too old visa message\n");
                         }
 
@@ -535,12 +535,7 @@ int main(int argc, char **argv)
                             *(uint8_t *)&visa_msg_buf = UDP_MSG_CHALLENGE;
 
                             if (err_no>0){
-                                if (err_no==1)
-                                    *(uint8_t *)((uint8_t *)&visa_msg_buf + 1) = VISA_MSG_EXPIRED;
-                                else if (err_no==2)
-                                    *(uint8_t *)((uint8_t *)&visa_msg_buf + 1) = VISA_MSG_TOO_LARGE;
-                                else if (err_no==3)
-                                    *(uint8_t *)((uint8_t *)&visa_msg_buf + 1) = VISA_MSG_VERSION_MISMATCHED;
+                                *(uint8_t *)((uint8_t *)&visa_msg_buf + 2) = err_no;
                             }
                             // Check if the visa data valid.
                             else if (memcmp(((unsigned char *)&visa_msg_buf + 5), &visa_token, sizeof(visa_token)) != 0)

--- a/hpws.c
+++ b/hpws.c
@@ -530,7 +530,7 @@ int main(int argc, char **argv)
                             int msg_size = 3;
                             *(uint8_t *)&visa_msg_buf = UDP_MSG_CHALLENGE;
 
-                            if (err_no>0)
+                            if (err_no > 0)
                                 *(uint8_t *)((uint8_t *)&visa_msg_buf + 2) = err_no;
                             // Check if the visa data valid.
                             else if (memcmp(((unsigned char *)&visa_msg_buf + 5), &visa_token, sizeof(visa_token)) != 0)
@@ -538,9 +538,6 @@ int main(int argc, char **argv)
                             else
                             {
                                 *(uint8_t *)((uint8_t *)&visa_msg_buf + 1) = VISA_MSG_ACCEPTED;
-                                
-                                
-                                const unsigned char challenge[CHALLENGE_SIZE];
                                 generate_challenge((unsigned char *)&visa_msg_buf + 2);
                                 visapass_add(addr, ttl_sec, ipv4, (unsigned char *)&visa_msg_buf + 2);
                                 msg_size = CHALLENGE_SIZE + 3;
@@ -559,7 +556,7 @@ int main(int argc, char **argv)
                             {
                                 *(uint8_t *)&visa_msg_buf = UDP_MSG_VISA_RES;
 
-                                if (err_no>0)
+                                if (err_no > 0)
                                     *(uint8_t *)((uint8_t *)&visa_msg_buf + 2) = err_no;
                                 // Check for the proof of work in the received data and send approval or rejection accordingly.
                                 else if (verify_pow(((unsigned char *)&visa_msg_buf + 5), challenge_sent, CHALLENGE_SIZE, *(int *)((unsigned char *)&visa_msg_buf + 37)))
@@ -2321,9 +2318,9 @@ bool verify_pow(const unsigned char *hash, const unsigned char *data, const size
 
 void generate_challenge(unsigned char *challenge) {
     // Seed the random number generator with the current time
-    srand(time(NULL));
-    uint32_t random_number = rand();
     time_t current_time = time(NULL);
+    srand(current_time);
+    uint32_t random_number = rand();
 
     // Combine random number and timestamp into a buffer
     char buffer[sizeof(random_number) + sizeof(current_time)];

--- a/hpws.c
+++ b/hpws.c
@@ -39,7 +39,7 @@
 #define CLIENT_SHUTDOWN_CYCLES 3
 #define CLIENT_SHUTDOWN_FINAL_TIMEOUT 5000 /* microseconds */
 #define HPWS_VERSION "0.9.0"
-#define POW_DIFFICULTY 6
+#define POW_DIFFICULTY 5
 #define _GNU_SOURCE
 
 #include <stdio.h>
@@ -496,20 +496,12 @@ int main(int argc, char **argv)
                             visapass_add(addr, ttl_sec, ipv4);
                             unsigned char visa_approval[] = "approve";
                             sendto(visa_sock, visa_approval, strlen(visa_approval), MSG_CONFIRM, (struct sockaddr*)&client_addr, client_addr_len);
-
-                            //////////////
-                            printf("=======================================================Approval sent.=======================================================\n");
-                            //////////////
                         }
                         else
                         {
                             unsigned char visa_reject[32] = "reject";
                             sendto(visa_sock, visa_reject, strlen(visa_reject), MSG_CONFIRM, (struct sockaddr*)&client_addr, client_addr_len);
                             fprintf(stderr, "Received invalid visa challenge\n");
-
-                            //////////////
-                            printf("=======================================================Rejection sent.=======================================================\n");
-                            //////////////
 
                             continue;
                         }
@@ -737,10 +729,6 @@ int main(int argc, char **argv)
                 ABEND(93, "could not send the visa request");
             }
 
-            //////////////
-            printf("=======================================================Request : %s.=======================================================\n", connect_ip);
-            //////////////
-
             unsigned char visa_response[32];
             int bytes_read = recvfrom(client_fd, visa_response, sizeof(visa_response), MSG_WAITALL, (struct sockaddr*)&client_addr, &client_addr_len);
             if (bytes_read < 1) {
@@ -748,10 +736,6 @@ int main(int argc, char **argv)
                 close(client_fd);
                 ABEND(94, "could not receive the visa response");
             }
-
-            //////////////
-            printf("=======================================================Response : %s=======================================================\n", visa_response);
-            //////////////
 
             if (strcmp(visa_response, "approve") != 0)
             {

--- a/hpws.c
+++ b/hpws.c
@@ -53,7 +53,7 @@
 #define VISA_MSG_TOO_LARGE 123
 #define VISA_MSG_VERSION_MISMATCH 124
 #define VISA_EXPIRY_TIME_SECONDS 60
-#define VISA_ID_WAIT_TIMEOUT 5000 /* ms */ // The delay used for visa id message polling.
+#define VISA_TCP_CONNECT_TIMEOUT 5000 /* ms */ // The delay used for visa id message polling.
 #define _GNU_SOURCE
 
 #include <stdio.h>
@@ -725,7 +725,7 @@ int main(int argc, char **argv)
             {
                 fdset[0].fd = client_fd;
                 fdset[0].events = POLLIN;
-                const int read_poll = poll(fdset, 1, VISA_ID_WAIT_TIMEOUT);
+                const int read_poll = poll(fdset, 1, VISA_TCP_CONNECT_TIMEOUT);
                 if (read_poll < 0)
                 {
                     GOTO_ERROR("incoming visa id poll error", force_closed);

--- a/hpws.c
+++ b/hpws.c
@@ -814,7 +814,7 @@ int main(int argc, char **argv)
             {
                 fprintf(stderr, "[HPWS.C PID+%08X] Unable to send connection init, errno: %d\n", my_pid, errno);
                 close(client_fd);
-                ABEND(93, "could not send the connection init");
+                ABEND(94, "could not send the connection init");
             }
 
             int bytes_read = recvfrom(client_fd, &visa_msg_buf, sizeof(visa_msg_buf), MSG_WAITALL, (struct sockaddr *)&client_addr, &client_addr_len);
@@ -822,7 +822,7 @@ int main(int argc, char **argv)
             {
                 fprintf(stderr, "[HPWS.C PID+%08X] Invalid challenge, errno: %d\n", my_pid, errno);
                 close(client_fd);
-                ABEND(94, "could not receive the challenge");
+                ABEND(95, "could not receive the challenge");
             }
 
             // Skip visa connection if challenge isn't received.
@@ -830,7 +830,7 @@ int main(int argc, char **argv)
             {
                 fprintf(stderr, "[HPWS.C PID+%08X] Didn't receive the challenge, errno: %d\n", my_pid, errno);
                 close(client_fd);
-                ABEND(95, "challenge didn't receive from the server");
+                ABEND(96, "challenge didn't receive from the server");
             }
 
             // Skip visa connection if init request isn't accepted.
@@ -855,7 +855,7 @@ int main(int argc, char **argv)
             {
                 fprintf(stderr, "[HPWS.C PID+%08X] Unable to request visa, errno: %d\n", my_pid, errno);
                 close(client_fd);
-                ABEND(96, "could not send the visa request");
+                ABEND(97, "could not send the visa request");
             }
 
             bytes_read = recvfrom(client_fd, &visa_msg_buf, sizeof(visa_msg_buf), MSG_WAITALL, (struct sockaddr *)&client_addr, &client_addr_len);
@@ -863,7 +863,7 @@ int main(int argc, char **argv)
             {
                 fprintf(stderr, "[HPWS.C PID+%08X] Invalid visa response, errno: %d\n", my_pid, errno);
                 close(client_fd);
-                ABEND(97, "could not receive the visa response");
+                ABEND(98, "could not receive the visa response");
             }
 
             // Skip tcp connection if visa response is not received.
@@ -871,7 +871,7 @@ int main(int argc, char **argv)
             {
                 fprintf(stderr, "[HPWS.C PID+%08X] Visa response not received, errno: %d\n", my_pid, errno);
                 close(client_fd);
-                ABEND(98, "visa response not received from the server");
+                ABEND(99, "visa response not received from the server");
             }
 
             // Skip tcp connection if visa is rejected.
@@ -889,7 +889,7 @@ int main(int argc, char **argv)
         if (connect(client_fd, (struct sockaddr *)&client_addr, client_addr_len))
         {
             fprintf(stderr, "[HPWS.C PID+%08X] Unable to connect, errno: %d\n", my_pid, errno);
-            ABEND(99, "can't connect");
+            ABEND(93, "can't connect");
         }
 
         // Set TCP no delay so OS packet buffering doesn't happen.

--- a/hpws.c
+++ b/hpws.c
@@ -514,12 +514,12 @@ int main(int argc, char **argv)
                             err_no = VISA_MSG_TOO_LARGE;
                             fprintf(stderr, "Visa message is too large %d\n", errno);
                         }
-                        else if (*(uint16_t *)((unsigned char *)&visa_msg_buf) != VISA_MSG_VERSION)
+                        else if (*(uint16_t *)&visa_msg_buf != VISA_MSG_VERSION)
                         {
                             err_no = VISA_MSG_VERSION_MISMATCH; // invalid message version
                             fprintf(stderr, "Received invalid visa message version\n");
                         }
-                        else if (*(int *)((unsigned char *)&visa_msg_buf + 3) <= time(NULL) - VISA_EXPIRY_TIME_SECONDS)
+                        else if (*(int *)&visa_msg_buf[3] <= time(NULL) - VISA_EXPIRY_TIME_SECONDS)
                         {
                             err_no = VISA_MSG_EXPIRED; // is message is too old
                             fprintf(stderr, "Received too old visa message\n");
@@ -529,23 +529,23 @@ int main(int argc, char **argv)
                         const uint32_t *addr = ipv4 ? &client_addr.sin.sin_addr.s_addr : (uint32_t *)&client_addr.sin6.sin6_addr;
 
                         // Populate the message version.
-                        *(uint16_t *)((unsigned char *)&visa_msg_buf) = VISA_MSG_VERSION;
+                        *(uint16_t *)&visa_msg_buf = VISA_MSG_VERSION;
 
                         int msg_size = 4;
-                        if (*(uint8_t *)((uint8_t *)&visa_msg_buf + 2) == UDP_MSG_INIT)
+                        if (visa_msg_buf[2] == UDP_MSG_INIT)
                         {
-                            *(uint8_t *)((uint8_t *)&visa_msg_buf + 2) = UDP_MSG_CHALLENGE;
+                            visa_msg_buf[2] = UDP_MSG_CHALLENGE;
 
                             if (err_no > 0)
-                                *(uint8_t *)((uint8_t *)&visa_msg_buf + 3) = err_no;
+                                visa_msg_buf[3] = err_no;
                             // Check if the visa data valid.
-                            else if (memcmp(((unsigned char *)&visa_msg_buf + 7), &visa_token, sizeof(visa_token)) != 0)
-                                *(uint8_t *)((uint8_t *)&visa_msg_buf + 3) = VISA_MSG_FAILED;
+                            else if (memcmp(&visa_msg_buf[7], &visa_token, sizeof(visa_token)) != 0)
+                                visa_msg_buf[3] = VISA_MSG_FAILED;
                             else
                             {
-                                *(uint8_t *)((uint8_t *)&visa_msg_buf + 3) = VISA_MSG_ACCEPTED;
-                                generate_challenge((unsigned char *)&visa_msg_buf + 4);
-                                visapass_add(addr, VISA_EXPIRY_TIME_SECONDS, ipv4, (unsigned char *)&visa_msg_buf + 4);
+                                visa_msg_buf[3] = VISA_MSG_ACCEPTED;
+                                generate_challenge(&visa_msg_buf[4]);
+                                visapass_add(addr, VISA_EXPIRY_TIME_SECONDS, ipv4, &visa_msg_buf[4]);
                                 msg_size += CHALLENGE_SIZE;
                             }
 
@@ -553,28 +553,28 @@ int main(int argc, char **argv)
 
                             continue;
                         }
-                        else if (*(uint8_t *)((uint8_t *)&visa_msg_buf + 2) == UDP_MSG_VISA_REQ)
+                        else if (visa_msg_buf[2] == UDP_MSG_VISA_REQ)
                         {
                             const unsigned char *challenge_sent = visapass_get_challenge(addr, ipv4);
 
                             // Check for the challenge sent for this client.
                             if (challenge_sent != NULL)
                             {
-                                *(uint8_t *)((uint8_t *)&visa_msg_buf + 2) = UDP_MSG_VISA_RES;
+                                visa_msg_buf[2] = UDP_MSG_VISA_RES;
 
                                 if (err_no > 0)
-                                    *(uint8_t *)((uint8_t *)&visa_msg_buf + 3) = err_no;
+                                    visa_msg_buf[3] = err_no;
                                 // Check for the proof of work in the received data and send approval or rejection accordingly.
-                                else if (verify_pow(((unsigned char *)&visa_msg_buf + 7), challenge_sent, CHALLENGE_SIZE, *(int *)((unsigned char *)&visa_msg_buf + 39)))
+                                else if (verify_pow(&visa_msg_buf[7], challenge_sent, CHALLENGE_SIZE, *(int *)&visa_msg_buf[39]))
                                 {
                                     // Send approval and mark visa as passed if pow is valid.
-                                    *(uint8_t *)((uint8_t *)&visa_msg_buf + 3) = VISA_MSG_ACCEPTED;
+                                    visa_msg_buf[3] = VISA_MSG_ACCEPTED;
                                     visapass_pass(addr, ipv4);
                                 }
                                 else
                                 {
                                     // Send rejection and remove visa pass if pow is invalid.
-                                    *(uint8_t *)((uint8_t *)&visa_msg_buf + 3) = VISA_MSG_REJECTED;
+                                    visa_msg_buf[3] = VISA_MSG_REJECTED;
                                     visapass_remove(addr, ipv4);
                                     fprintf(stderr, "Received invalid visa challenge\n");
                                 }
@@ -806,10 +806,10 @@ int main(int argc, char **argv)
             client_fd = socket(res->ai_family, SOCK_DGRAM, 0);
 
             // Send the intension to connect.
-            *(uint16_t *)((unsigned char *)&visa_msg_buf) = VISA_MSG_VERSION;
-            *(uint8_t *)((uint8_t *)&visa_msg_buf + 2) = UDP_MSG_INIT;
-            *(int *)((unsigned char *)&visa_msg_buf + 3) = time(NULL);
-            memcpy(((unsigned char *)&visa_msg_buf + 7), &visa_token, sizeof(visa_token));
+            *(uint16_t *)&visa_msg_buf = VISA_MSG_VERSION;
+            visa_msg_buf[2] = UDP_MSG_INIT;
+            *(int *)&visa_msg_buf[3] = time(NULL);
+            memcpy(&visa_msg_buf[7], &visa_token, sizeof(visa_token));
             if (sendto(client_fd, &visa_msg_buf, sizeof(visa_token) + 7, MSG_CONFIRM, (struct sockaddr *)&client_addr, client_addr_len) < 0)
             {
                 fprintf(stderr, "[HPWS.C PID+%08X] Unable to send connection init, errno: %d\n", my_pid, errno);
@@ -826,7 +826,7 @@ int main(int argc, char **argv)
             }
 
             // Skip visa connection if challenge isn't received.
-            if (*(uint8_t *)((uint8_t *)&visa_msg_buf + 2) != UDP_MSG_CHALLENGE)
+            if (visa_msg_buf[2] != UDP_MSG_CHALLENGE)
             {
                 fprintf(stderr, "[HPWS.C PID+%08X] Didn't receive the challenge, errno: %d\n", my_pid, errno);
                 close(client_fd);
@@ -834,23 +834,23 @@ int main(int argc, char **argv)
             }
 
             // Skip visa connection if init request isn't accepted.
-            if (*(uint8_t *)((uint8_t *)&visa_msg_buf + 3) != VISA_MSG_ACCEPTED)
+            if (visa_msg_buf[3] != VISA_MSG_ACCEPTED)
             {
                 fprintf(stderr, "[HPWS.C PID+%08X] Init request rejected, errno: %d\n", my_pid, errno);
                 close(client_fd);
-                ABEND(*(uint8_t *)((uint8_t *)&visa_msg_buf + 3), "init request rejected from the server");
+                ABEND(visa_msg_buf[3], "init request rejected from the server");
             }
 
             // Create visa request with the pow and send to the server.
-            *(uint16_t *)((unsigned char *)&visa_msg_buf) = VISA_MSG_VERSION;
-            *(uint8_t *)((uint8_t *)&visa_msg_buf + 2) = UDP_MSG_VISA_REQ;
+            *(uint16_t *)&visa_msg_buf = VISA_MSG_VERSION;
+            visa_msg_buf[2] = UDP_MSG_VISA_REQ;
             int nonce = 0;
             unsigned char hash[SHA256_DIGEST_LENGTH];
-            calculate_pow(((unsigned char *)&visa_msg_buf + 4), CHALLENGE_SIZE, &hash, (int *)&nonce);
+            calculate_pow(&visa_msg_buf[4], CHALLENGE_SIZE, &hash, (int *)&nonce);
 
-            *(int *)((unsigned char *)&visa_msg_buf + 3) = time(NULL);
-            memcpy(((unsigned char *)&visa_msg_buf + 7), &hash, sizeof(hash));
-            *(int *)((unsigned char *)&visa_msg_buf + 39) = nonce;
+            *(int *)&visa_msg_buf[3] = time(NULL);
+            memcpy(&visa_msg_buf[7], &hash, sizeof(hash));
+            *(int *)&visa_msg_buf[39] = nonce;
             if (sendto(client_fd, &visa_msg_buf, 43, MSG_CONFIRM, (struct sockaddr *)&client_addr, client_addr_len) < 0)
             {
                 fprintf(stderr, "[HPWS.C PID+%08X] Unable to request visa, errno: %d\n", my_pid, errno);
@@ -867,7 +867,7 @@ int main(int argc, char **argv)
             }
 
             // Skip tcp connection if visa response is not received.
-            if (*(uint8_t *)((uint8_t *)&visa_msg_buf + 2) != UDP_MSG_VISA_RES)
+            if (visa_msg_buf[2] != UDP_MSG_VISA_RES)
             {
                 fprintf(stderr, "[HPWS.C PID+%08X] Visa response not received, errno: %d\n", my_pid, errno);
                 close(client_fd);
@@ -875,7 +875,7 @@ int main(int argc, char **argv)
             }
 
             // Skip tcp connection if visa is rejected.
-            if (*(uint8_t *)((uint8_t *)&visa_msg_buf + 3) != VISA_MSG_ACCEPTED)
+            if (visa_msg_buf[3] != VISA_MSG_ACCEPTED)
             {
                 fprintf(stderr, "[HPWS.C PID+%08X] Visa rejected, errno: %d\n", my_pid, errno);
                 close(client_fd);

--- a/hpws.c
+++ b/hpws.c
@@ -53,6 +53,7 @@
 #define VISA_MSG_TOO_LARGE 123
 #define VISA_MSG_VERSION_MISMATCH 124
 #define VISA_EXPIRY_TIME_SECONDS 60
+#define VISA_ID_WAIT_TIMEOUT 5000 /* ms */ // The delay used for visa id message polling.
 #define _GNU_SOURCE
 
 #include <stdio.h>
@@ -723,7 +724,7 @@ int main(int argc, char **argv)
             {
                 fdset[0].fd = client_fd;
                 fdset[0].events = POLLIN;
-                const int read_poll = poll(fdset, 1, POLL_TIMEOUT);
+                const int read_poll = poll(fdset, 1, VISA_ID_WAIT_TIMEOUT);
                 if (read_poll < 0)
                 {
                     GOTO_ERROR("incoming visa id poll error", force_closed);

--- a/hpws.c
+++ b/hpws.c
@@ -46,7 +46,7 @@
 #define UDP_MSG_VISA_RES 4
 #define VISA_MSG_VERSION 1
 #define VISA_MSG_ACCEPTED 1
-#define VISA_MSG_REJECTED 120
+#define VISA_MSG_REJECTED 120 /* Error code are starting from 120 because it'll be passed as ABEND exit code */
 #define VISA_MSG_FAILED 121
 #define VISA_MSG_EXPIRED 122
 #define VISA_MSG_TOO_LARGE 123

--- a/hpws.c
+++ b/hpws.c
@@ -197,12 +197,12 @@ int main(int argc, char **argv)
     size_t client_addr_len = sizeof(client_addr); memset(&client_addr, 0, client_addr_len);
     int client_fd = -1, control_fd[2] = {-1,-2}, master_control_fd = -1, port = 443, max_con = 512;
     int arg_control_fd_2 = -1; // this is passed in connect mode at the commandline and becomes control_fd[1]
-    int  max_con_ip = 5, is_server = 1, is_ipv6 = 0, visa_required = 0;
+    int  max_con_ip = 5, is_server = 1, is_ipv6 = 0, is_ipv4 = 0, visa_required = 0;
     int urand_fd = -1;
     char ip[40]; ip[0] = '\0';
     char host[256]; host[0] = '\0';             // this is the host as parsed from the cmdline when in client mode
     char get[256]; get[0] = '/'; get[1] = '\0'; // this is the uri to request in the upgrade message when connecting
-    char visa_data[256]; visa_data[0] = '\0';   // this is the visa data for pow calculation when connecting with visa
+    char visa_token[256]; visa_token[0] = '\0'; // this is the visa data for pow calculation when connecting with visa
     int client_shutdown = 0;
 
     // UDP visa variables
@@ -269,7 +269,8 @@ int main(int argc, char **argv)
             {"ipv6",        no_argument,        0,      1 },
             {"get",         required_argument,  0,      1 },
             {"cntlfd2",     required_argument,  0,      1 },
-            {"visadata",    required_argument,  0,      1 },
+            {"visatoken",   required_argument,  0,      1 },
+            {"ipv4",        no_argument,        0,      1 },
             {0,             0,                  0,      0 }
         };
 
@@ -322,7 +323,10 @@ int main(int argc, char **argv)
                     PARSE_INT_OR_EXIT(optarg, "cntlfd2", arg_control_fd_2);
                     continue;
                 case 13:
-                    strncpy(visa_data, optarg, sizeof(visa_data));
+                    strncpy(visa_token, optarg, sizeof(visa_token));
+                    continue;
+                case 14:
+                    is_ipv4 = 1;
                     continue;
                 default:
                     continue;
@@ -350,7 +354,7 @@ int main(int argc, char **argv)
         if (!is_server && arg_control_fd_2 == -1)
             ABEND(41, "must specify --cntlfd2 <fd> when using connect mode, this is the hpcore->hpws line");
 
-        visa_required = strlen(visa_data) > 0;
+        visa_required = strlen(visa_token) > 0;
     }
 /*
 ** --------------------------------------------------------------------------------------------------------------------
@@ -385,12 +389,13 @@ int main(int argc, char **argv)
             if (visa_required)
             {
                 visa_sock = socket(is_ipv6 ? AF_INET6 : AF_INET, SOCK_DGRAM, 0);
-                if (visa_sock < 0) {
+                if (visa_sock < 0)
+                {
                     perror("Unable to create udp socket");
                     ABEND(68, "could not create udp socket");
                 }
 
-                if (bind(visa_sock, (struct sockaddr*)&(addr.sa), sizeof(addr)) < 0)
+                if (bind(visa_sock, (struct sockaddr *)&(addr.sa), sizeof(addr)) < 0)
                     ABEND(69, "could not bind socket for visa");
             }
 
@@ -478,8 +483,8 @@ int main(int argc, char **argv)
                 {
                     fdset[0].fd = visa_sock;
                     fdset[0].events = POLLIN;
-                    
-                    while(true)
+
+                    while (true)
                     {
                         const int visa_poll = poll(fdset, 1, 1);
 
@@ -492,8 +497,9 @@ int main(int argc, char **argv)
                         if (visa_poll == 0) // No incoming visa request.
                             break;
 
-                        int bytes_read = recvfrom(visa_sock, &visa_msg_buf, sizeof(visa_msg_buf), MSG_WAITALL, (struct sockaddr*)&client_addr, &client_addr_len);
-                        if (bytes_read < 1) {
+                        int bytes_read = recvfrom(visa_sock, &visa_msg_buf, sizeof(visa_msg_buf), MSG_WAITALL, (struct sockaddr *)&client_addr, &client_addr_len);
+                        if (bytes_read < 1)
+                        {
                             fprintf(stderr, "Received invalid visa request %d\n", errno);
                             continue;
                         }
@@ -518,7 +524,7 @@ int main(int argc, char **argv)
                             if (is_too_old)
                                 *(uint8_t *)((uint8_t *)&visa_msg_buf + 1) = VISA_MSG_EXPIRED;
                             // Check if the visa data valid.
-                            else if (memcmp(((unsigned char *)&visa_msg_buf + 5), &visa_data, sizeof(visa_data)) != 0)
+                            else if (memcmp(((unsigned char *)&visa_msg_buf + 5), &visa_token, sizeof(visa_token)) != 0)
                                 *(uint8_t *)((uint8_t *)&visa_msg_buf + 1) = VISA_MSG_FAILED;
                             else
                             {
@@ -529,8 +535,8 @@ int main(int argc, char **argv)
                                 visapass_add(addr, ttl_sec, ipv4, (unsigned char *)&challenge);
                                 msg_size = CHALLENGE_SIZE + 1;
                             }
-                            
-                            sendto(visa_sock, &visa_msg_buf, msg_size, MSG_CONFIRM, (struct sockaddr*)&client_addr, client_addr_len);
+
+                            sendto(visa_sock, &visa_msg_buf, msg_size, MSG_CONFIRM, (struct sockaddr *)&client_addr, client_addr_len);
 
                             continue;
                         }
@@ -560,7 +566,7 @@ int main(int argc, char **argv)
                                     fprintf(stderr, "Received invalid visa challenge\n");
                                 }
 
-                                sendto(visa_sock, &visa_msg_buf, 2, MSG_CONFIRM, (struct sockaddr*)&client_addr, client_addr_len);
+                                sendto(visa_sock, &visa_msg_buf, 2, MSG_CONFIRM, (struct sockaddr *)&client_addr, client_addr_len);
 
                                 continue;
                             }
@@ -617,7 +623,7 @@ int main(int argc, char **argv)
                         close(client_fd);
                         continue;
                     }
-                    
+
                     // Remove the visa from visa passes.
                     visapass_remove(addr, ipv4);
                 }
@@ -759,7 +765,11 @@ int main(int argc, char **argv)
         snprintf(p, 10, "%d", port);
         if (DEBUG)
             fprintf(stderr, "[HPWS.C PID+%08X] resolving host: %.*s\n", my_pid, sizeof(host), host);
-        int rc = getaddrinfo(host, p, NULL, &res);
+
+        struct addrinfo hint;
+        memset(&hint, 0, sizeof(hint));
+        hint.ai_family = is_ipv4 ? AF_INET : AF_UNSPEC;
+        int rc = getaddrinfo(host, p, &hint, &res);
         if (rc)
             ABEND(91, gai_strerror(rc));
 
@@ -780,21 +790,22 @@ int main(int argc, char **argv)
 
         if (visa_required)
         {
-            client_fd = socket( res->ai_family, SOCK_DGRAM, 0 );
+            client_fd = socket(res->ai_family, SOCK_DGRAM, 0);
 
             // Send the intension to connect.
             *(uint8_t *)&visa_msg_buf = UDP_MSG_INIT;
             *(int *)((unsigned char *)&visa_msg_buf + 1) = time(NULL);
-            memcpy(((unsigned char *)&visa_msg_buf + 5), &visa_data, sizeof(visa_data));
-            if (sendto(client_fd, &visa_msg_buf, sizeof(visa_data) + 5, MSG_CONFIRM, (struct sockaddr *)&client_addr, client_addr_len) < 0)
+            memcpy(((unsigned char *)&visa_msg_buf + 5), &visa_token, sizeof(visa_token));
+            if (sendto(client_fd, &visa_msg_buf, sizeof(visa_token) + 5, MSG_CONFIRM, (struct sockaddr *)&client_addr, client_addr_len) < 0)
             {
                 fprintf(stderr, "[HPWS.C PID+%08X] Unable to send connection init, errno: %d\n", my_pid, errno);
                 close(client_fd);
                 ABEND(93, "could not send the connection init");
             }
 
-            int bytes_read = recvfrom(client_fd, &visa_msg_buf, sizeof(visa_msg_buf), MSG_WAITALL, (struct sockaddr*)&client_addr, &client_addr_len);
-            if (bytes_read < 1) {
+            int bytes_read = recvfrom(client_fd, &visa_msg_buf, sizeof(visa_msg_buf), MSG_WAITALL, (struct sockaddr *)&client_addr, &client_addr_len);
+            if (bytes_read < 1)
+            {
                 fprintf(stderr, "[HPWS.C PID+%08X] Invalid challenge, errno: %d\n", my_pid, errno);
                 close(client_fd);
                 ABEND(94, "could not receive the challenge");
@@ -821,7 +832,7 @@ int main(int argc, char **argv)
             int nonce = 0;
             unsigned char hash[SHA256_DIGEST_LENGTH];
             calculate_pow(((unsigned char *)&visa_msg_buf + 1), CHALLENGE_SIZE, &hash, (int *)&nonce);
-            
+
             *(int *)((unsigned char *)&visa_msg_buf + 1) = time(NULL);
             memcpy(((unsigned char *)&visa_msg_buf + 5), &hash, sizeof(hash));
             *(int *)((unsigned char *)&visa_msg_buf + 37) = nonce;
@@ -832,8 +843,9 @@ int main(int argc, char **argv)
                 ABEND(96, "could not send the visa request");
             }
 
-            bytes_read = recvfrom(client_fd, &visa_msg_buf, sizeof(visa_msg_buf), MSG_WAITALL, (struct sockaddr*)&client_addr, &client_addr_len);
-            if (bytes_read < 1) {
+            bytes_read = recvfrom(client_fd, &visa_msg_buf, sizeof(visa_msg_buf), MSG_WAITALL, (struct sockaddr *)&client_addr, &client_addr_len);
+            if (bytes_read < 1)
+            {
                 fprintf(stderr, "[HPWS.C PID+%08X] Invalid visa response, errno: %d\n", my_pid, errno);
                 close(client_fd);
                 ABEND(97, "could not receive the visa response");

--- a/hpws.c
+++ b/hpws.c
@@ -46,11 +46,11 @@
 #define UDP_MSG_CHALLENGE 3
 #define UDP_MSG_VISA_RES 4
 #define VISA_MSG_ACCEPTED 1
-#define VISA_MSG_REJECTED 2
-#define VISA_MSG_FAILED 3
-#define VISA_MSG_EXPIRED 4
-#define VISA_MSG_TOO_LARGE 5
-#define VISA_MSG_VERSION_MISMATCHED 6
+#define VISA_MSG_REJECTED 120
+#define VISA_MSG_FAILED 121
+#define VISA_MSG_EXPIRED 122
+#define VISA_MSG_TOO_LARGE 123
+#define VISA_MSG_VERSION_MISMATCHED 124
 #define VISA_EXPIRY_TIME_SECONDS 60
 #define _GNU_SOURCE
 
@@ -491,7 +491,6 @@ int main(int argc, char **argv)
                     while(true)
                     {
                         const int visa_poll = poll(fdset, 1, 1);
-                        bool is_too_large=false;
                         // 0 if no error
                         int err_no = 0;
 
@@ -500,8 +499,7 @@ int main(int argc, char **argv)
                             perror("visa request poll");
                             exit(1);
                         }
-
-                        if (visa_poll == 0) // No incoming visa request.
+                        else if (visa_poll == 0) // No incoming visa request.
                             break;
 
                         int bytes_read = recvfrom(visa_sock, &visa_msg_buf, sizeof(visa_msg_buf), MSG_WAITALL, (struct sockaddr *)&client_addr, &client_addr_len);
@@ -510,10 +508,9 @@ int main(int argc, char **argv)
                             fprintf(stderr, "Received invalid visa request %d\n", errno);
                             continue;
                         }
-                        if (bytes_read > sizeof(visa_msg_buf)){
-                            is_too_large = true;
+                        else if (bytes_read > sizeof(visa_msg_buf)){
                             // if message is too large
-                            err_no = 2;
+                            err_no = VISA_MSG_TOO_LARGE;
                             fprintf(stderr, "Visa request is too large %d\n", errno);
                             continue;
                         }

--- a/hpws.hpp
+++ b/hpws.hpp
@@ -775,6 +775,10 @@ namespace hpws
             if (ret < 1)
                 HPWS_ACCEPT_ERROR(202, "timeout waiting for hpws accept child message");
 
+            // check weather write end in forcefully closed closed
+            if (pfd.revents & POLLHUP)
+                HPWS_ACCEPT_ERROR(205, "child connection closed");
+
             // first thing we'll receive is the pid of the client
             if (recv(child_fd[0], (unsigned char *)(&pid), sizeof(pid), 0) < (ssize_t)sizeof(pid))
                 HPWS_ACCEPT_ERROR(212, "did not receive expected 4 byte pid of child process on accept");

--- a/hpws.hpp
+++ b/hpws.hpp
@@ -775,7 +775,7 @@ namespace hpws
             if (ret < 1)
                 HPWS_ACCEPT_ERROR(202, "timeout waiting for hpws accept child message");
 
-            // check weather write end in forcefully closed
+            // check whether write end in forcefully closed
             if (pfd.revents & POLLHUP)
                 HPWS_ACCEPT_ERROR(205, "child connection closed");
 

--- a/hpws.hpp
+++ b/hpws.hpp
@@ -775,7 +775,7 @@ namespace hpws
             if (ret < 1)
                 HPWS_ACCEPT_ERROR(202, "timeout waiting for hpws accept child message");
 
-            // check weather write end in forcefully closed closed
+            // check weather write end in forcefully closed
             if (pfd.revents & POLLHUP)
                 HPWS_ACCEPT_ERROR(205, "child connection closed");
 

--- a/hpws.hpp
+++ b/hpws.hpp
@@ -426,7 +426,7 @@ namespace hpws
 
                 // we will set a timeout and wait for the initial startup message from hpws client mode
                 struct pollfd pfd;
-                int ret;
+                int ret = 0;
 
                 pfd.fd = child_fd[0]; // we receive setup events on control line 0 (hpws->hpcore)
                 pfd.events = POLLIN;

--- a/hpws.hpp
+++ b/hpws.hpp
@@ -321,6 +321,7 @@ namespace hpws
             std::string_view host,
             uint16_t port,
             std::string_view get,
+            bool visa_req,
             std::vector<std::string_view> argv,
             std::function<void()> fork_child_init = NULL)
         {
@@ -381,6 +382,8 @@ namespace hpws
                 argv_pass[upto++] = cfd2;
                 argv_pass[upto++] = "--get";
                 argv_pass[upto++] = get.data();
+                if (visa_req)
+                    argv_pass[upto++] = "--visareq";
                 for (std::string_view &arg : argv)
                     argv_pass[upto++] = arg.data();
                 argv_pass[upto] = NULL;
@@ -876,6 +879,7 @@ namespace hpws
             uint16_t max_con_per_ip,
             std::string_view cert_path,
             std::string_view key_path,
+            bool visa_req,
             std::vector<std::string_view> argv, //additional_arguments
             std::function<void()> fork_child_init = NULL)
         {
@@ -934,6 +938,8 @@ namespace hpws
                 argv_pass[upto++] = max_con_str;
                 argv_pass[upto++] = "--maxconip";
                 argv_pass[upto++] = max_con_per_ip_str;
+                if (visa_req)
+                    argv_pass[upto++] = "--visareq";
                 for (std::string_view &arg : argv)
                     argv_pass[upto++] = arg.data();
                 argv_pass[upto] = NULL;

--- a/hpws.hpp
+++ b/hpws.hpp
@@ -340,7 +340,7 @@ namespace hpws
             int buffer_fd[4] = {-1, -1, -1, -1};
             void *mapping[4] = {NULL, NULL, NULL, NULL};
             int pid = -1;
-            int count_args = 14 + argv.size();
+            int count_args = 14 + (visa_data.has_value() ? 2 : 0) + argv.size();
             char const **argv_pass = NULL;
 
             if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, fd))
@@ -898,7 +898,7 @@ namespace hpws
             const char *error_msg = NULL;
             int fd[2] = {-1, -1};
             pid_t pid = -1;
-            int count_args = 17 + argv.size();
+            int count_args = 16 + (visa_data.has_value() ? 2 : 0) + argv.size();
             char const **argv_pass = NULL;
 
             if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, fd))

--- a/hpws.hpp
+++ b/hpws.hpp
@@ -47,7 +47,7 @@ namespace hpws
 // used when waiting for messages that should already be on the pipe
 #define HPWS_SMALL_TIMEOUT 10
 // used when waiting for server process to spawn
-#define HPWS_LONG_TIMEOUT 1500  // This timeout has to account the possible delays in communication via internet.
+#define HPWS_LONG_TIMEOUT 1500 // This timeout has to account the possible delays in communication via internet.
 #define HPWS_VISA_TIMEOUT 5000 // This timeout has to account the possible delays in visa pow calculation.
 
     typedef union

--- a/test/echo-client.cpp
+++ b/test/echo-client.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 int get_case_count()
 {
     const std::string path = "/getCaseCount";
-    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, {});
+    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, true, {});
 
     if (std::holds_alternative<hpws::client>(accept_result))
     {
@@ -79,7 +79,7 @@ int get_case_count()
 int echo_client(const uint32_t caseid)
 {
     const std::string path = "/runCase?case=" + std::to_string(caseid) + "&agent=" + AGENT;
-    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, {});
+    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, true, {});
 
     if (std::holds_alternative<hpws::client>(accept_result))
     {
@@ -118,7 +118,7 @@ int echo_client(const uint32_t caseid)
 int update_reports()
 {
     const std::string path = std::string("/updateReports?agent=") + AGENT;
-    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, {});
+    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, true, {});
 
     if (std::holds_alternative<hpws::client>(accept_result))
     {

--- a/test/echo-client.cpp
+++ b/test/echo-client.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 int get_case_count()
 {
     const std::string path = "/getCaseCount";
-    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, true, {});
+    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, "visa_data", {});
 
     if (std::holds_alternative<hpws::client>(accept_result))
     {
@@ -79,7 +79,7 @@ int get_case_count()
 int echo_client(const uint32_t caseid)
 {
     const std::string path = "/runCase?case=" + std::to_string(caseid) + "&agent=" + AGENT;
-    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, true, {});
+    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, "visa_data", {});
 
     if (std::holds_alternative<hpws::client>(accept_result))
     {
@@ -118,7 +118,7 @@ int echo_client(const uint32_t caseid)
 int update_reports()
 {
     const std::string path = std::string("/updateReports?agent=") + AGENT;
-    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, true, {});
+    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, "visa_data", {});
 
     if (std::holds_alternative<hpws::client>(accept_result))
     {

--- a/test/echo-client.cpp
+++ b/test/echo-client.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 int get_case_count()
 {
     const std::string path = "/getCaseCount";
-    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, "visa_data", {});
+    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, {});
 
     if (std::holds_alternative<hpws::client>(accept_result))
     {
@@ -79,7 +79,7 @@ int get_case_count()
 int echo_client(const uint32_t caseid)
 {
     const std::string path = "/runCase?case=" + std::to_string(caseid) + "&agent=" + AGENT;
-    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, "visa_data", {});
+    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, {});
 
     if (std::holds_alternative<hpws::client>(accept_result))
     {
@@ -118,7 +118,7 @@ int echo_client(const uint32_t caseid)
 int update_reports()
 {
     const std::string path = std::string("/updateReports?agent=") + AGENT;
-    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, "visa_data", {});
+    auto accept_result = hpws::client::connect("hpws", 16 * 1024 * 1024, SERVER, PORT, path, {});
 
     if (std::holds_alternative<hpws::client>(accept_result))
     {

--- a/test/echo-server.cpp
+++ b/test/echo-server.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
 
 int echo_server()
 {
-    auto server = hpws::server::create("hpws", 16 * 1024 * 1024, 8080, 512, 512, "cert.pem", "key.pem", {});
+    auto server = hpws::server::create("hpws", 16 * 1024 * 1024, 8080, 512, 512, "cert.pem", "key.pem", true, {});
 
     if (std::holds_alternative<hpws::server>(server))
     {

--- a/test/echo-server.cpp
+++ b/test/echo-server.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
 
 int echo_server()
 {
-    auto server = hpws::server::create("hpws", 16 * 1024 * 1024, 8080, 512, 512, "cert.pem", "key.pem", true, {});
+    auto server = hpws::server::create("hpws", 16 * 1024 * 1024, 8080, 512, 512, "cert.pem", "key.pem", "visa_data", {});
 
     if (std::holds_alternative<hpws::server>(server))
     {
@@ -51,9 +51,9 @@ int echo_server()
                 PRINT_HPWS_ERROR(accept_result);
                 continue;
             }
-            
+
             ([](hpws::client client)
-            {
+             {
 
                 for (;;)
                 {
@@ -72,8 +72,7 @@ int echo_server()
 
                     // Reply with the same message we got.
                     client.write(in_msg);
-                }
-            })(std::get<hpws::client>(std::move(accept_result)));
+                } })(std::get<hpws::client>(std::move(accept_result)));
         }
     }
     else if (std::holds_alternative<hpws::error>(server))

--- a/test/echo-server.cpp
+++ b/test/echo-server.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
 
 int echo_server()
 {
-    auto server = hpws::server::create("hpws", 16 * 1024 * 1024, 8080, 512, 512, "cert.pem", "key.pem", "visa_data", {});
+    auto server = hpws::server::create("hpws", 16 * 1024 * 1024, 8080, 512, 512, "cert.pem", "key.pem", {});
 
     if (std::holds_alternative<hpws::server>(server))
     {

--- a/visapass.h
+++ b/visapass.h
@@ -9,12 +9,13 @@
 #define __IP_V4 1
 #define __IP_V6 2
 #define CHALLENGE_SIZE 32
+#define ID_SIZE 32
 
 struct __visapass_slot
 {
-    uint8_t type;                            // 0 = none, 1 = ipv4, 2 = ipv6
+    uint8_t occupied;                        // 0 = vacant, 1 = occupied.
     time_t expire;                           // Epoch seconds at which the visa will expire.
-    uint32_t addr[4];                        // In ipv4 first element will be filled. ipv6 will fill all 4 elements.
+    unsigned char id[ID_SIZE];               // Identifier for the slot.
     unsigned char challenge[CHALLENGE_SIZE]; // Issued visa challenge.
     bool passed;                             // Whether visa is passed.
 };
@@ -25,44 +26,24 @@ static int __visapass_filled_boundry = 0; // Indicates the last slot that has be
 /**
  * @return Pointer if found. NULL if not found/expired.
  */
-struct __visapass_slot *__visapass_find(const uint32_t *addr, const uint8_t type)
+struct __visapass_slot *__visapass_find(const unsigned char *id)
 {
     struct __visapass_slot *found = NULL;
 
-    if (type == __IP_V4)
+    for (int i = 0; i < __visapass_filled_boundry; i++)
     {
-        for (int i = 0; i < __visapass_filled_boundry; i++)
+        struct __visapass_slot *slot = &__visapasses[i];
+        if (slot->occupied == 1 && memcmp(slot->id, id, ID_SIZE) == 0)
         {
-            struct __visapass_slot *slot = &__visapasses[i];
-            if (slot->type == type &&
-                slot->addr[0] == *addr)
-            {
-                found = slot;
-                break;
-            }
-        }
-    }
-    else
-    {
-        for (int i = 0; i < __visapass_filled_boundry; i++)
-        {
-            struct __visapass_slot *slot = &__visapasses[i];
-            if (slot->type == type &&
-                slot->addr[0] == addr[0] &&
-                slot->addr[1] == addr[1] &&
-                slot->addr[2] == addr[2] &&
-                slot->addr[3] == addr[3])
-            {
-                found = slot;
-                break;
-            }
+            found = slot;
+            break;
         }
     }
 
     // If the slot we found has expired, clean it up.
     if (found && found->expire <= time(NULL))
     {
-        found->type = 0; // Mark the slot as vacant.
+        found->occupied = 0; // Mark the slot as vacant.
         found = NULL;
     }
 
@@ -71,20 +52,25 @@ struct __visapass_slot *__visapass_find(const uint32_t *addr, const uint8_t type
 
 // Public interface-------------------------
 
+void visapass_pass(const unsigned char *id)
+{
+    struct __visapass_slot *slot = __visapass_find(id);
+    if (slot)
+        slot->passed = true;
+}
+
 /**
  * @return 0 if success. -1 if failure (due to all slots being filled).
  */
-int visapass_add(const uint32_t *addr, const uint32_t ttl_sec, const bool ipv4, const unsigned char *challenge)
+int visapass_add(const unsigned char *id, const uint32_t ttl_sec, const unsigned char *challenge)
 {
-    const uint8_t type = (ipv4 ? __IP_V4 : __IP_V6);
-
     // Check if already exists.
-    struct __visapass_slot *slot = __visapass_find(addr, type);
+    struct __visapass_slot *slot = __visapass_find(id);
     if (!slot) // If not existing, find first vacant slot.
     {
         for (int i = 0; i < __VISAPASS_SLOT_COUNT; i++)
         {
-            if (__visapasses[i].type == 0)
+            if (__visapasses[i].occupied == 0)
             {
                 slot = &__visapasses[i];
                 if (__visapass_filled_boundry < i + 1)
@@ -96,22 +82,11 @@ int visapass_add(const uint32_t *addr, const uint32_t ttl_sec, const bool ipv4, 
 
     if (slot)
     {
-        slot->type = type;
+        slot->occupied = 1;
         slot->expire = time(NULL) + ttl_sec;
         slot->passed = false;
         memcpy(slot->challenge, challenge, CHALLENGE_SIZE);
-
-        if (type == __IP_V4)
-        {
-            slot->addr[0] = *addr;
-        }
-        else
-        {
-            slot->addr[0] = addr[0];
-            slot->addr[1] = addr[1];
-            slot->addr[2] = addr[2];
-            slot->addr[3] = addr[3];
-        }
+        memcpy(slot->id, id, ID_SIZE);
 
         return 0;
     }
@@ -119,29 +94,22 @@ int visapass_add(const uint32_t *addr, const uint32_t ttl_sec, const bool ipv4, 
     return -1;
 }
 
-void visapass_pass(const uint32_t *addr, const bool ipv4)
+void visapass_remove(const unsigned char *id)
 {
-    struct __visapass_slot *slot = __visapass_find(addr, (ipv4 ? __IP_V4 : __IP_V6));
+    struct __visapass_slot *slot = __visapass_find(id);
     if (slot)
-        slot->passed = true;
+        slot->occupied = 0;
 }
 
-void visapass_remove(const uint32_t *addr, const bool ipv4)
+bool visapass_is_passed(const unsigned char *id)
 {
-    struct __visapass_slot *slot = __visapass_find(addr, (ipv4 ? __IP_V4 : __IP_V6));
-    if (slot)
-        slot->type = 0;
-}
-
-bool visapass_is_passed(const uint32_t *addr, const bool ipv4)
-{
-    struct __visapass_slot *slot = __visapass_find(addr, (ipv4 ? __IP_V4 : __IP_V6));
+    struct __visapass_slot *slot = __visapass_find(id);
     return slot != NULL && slot->passed;
 }
 
-const unsigned char *visapass_get_challenge(const uint32_t *addr, const bool ipv4)
+const unsigned char *visapass_get_challenge(const unsigned char *id)
 {
-    struct __visapass_slot *slot = __visapass_find(addr, (ipv4 ? __IP_V4 : __IP_V6));
+    struct __visapass_slot *slot = __visapass_find(id);
     if (slot)
         return (const unsigned char *)slot->challenge;
     return NULL;

--- a/visapass.h
+++ b/visapass.h
@@ -136,7 +136,7 @@ void visapass_remove(const uint32_t *addr, const bool ipv4)
 bool visapass_is_passed(const uint32_t *addr, const bool ipv4)
 {
     struct __visapass_slot *slot = __visapass_find(addr, (ipv4 ? __IP_V4 : __IP_V6));
-    return slot->passed;
+    return slot != NULL && slot->passed;
 }
 
 const unsigned char *visapass_get_challenge(const uint32_t *addr, const bool ipv4)

--- a/visapass.h
+++ b/visapass.h
@@ -6,8 +6,6 @@
 #include <stdbool.h>
 
 #define __VISAPASS_SLOT_COUNT 100
-#define __IP_V4 1
-#define __IP_V6 2
 #define CHALLENGE_SIZE 32
 #define ID_SIZE 32
 

--- a/visapass.h
+++ b/visapass.h
@@ -1,0 +1,129 @@
+#ifndef HPWS_VISAPASS
+#define HPWS_VISAPASS
+
+#include <stdint.h>
+#include <time.h>
+#include <stdbool.h>
+
+#define __VISAPASS_SLOT_COUNT 100
+#define __IP_V4 1
+#define __IP_V6 2
+
+struct __visapass_slot
+{
+    uint8_t type;     // 0 = none, 1 = ipv4, 2 = ipv6
+    time_t expire;    // Epoch seconds at which the visa will expire.
+    uint32_t addr[4]; // In ipv4 first element will be filled. ipv6 will fill all 4 elements.
+};
+
+static struct __visapass_slot __visapasses[__VISAPASS_SLOT_COUNT];
+static int __visapass_filled_boundry = 0; // Indicates the last slot that has been touched.
+
+/**
+ * @return Pointer if found. NULL if not found/expired.
+ */
+struct __visapass_slot *__visapass_find(const uint32_t *addr, const uint8_t type)
+{
+    struct __visapass_slot *found = NULL;
+
+    if (type == __IP_V4)
+    {
+        for (int i = 0; i < __visapass_filled_boundry; i++)
+        {
+            struct __visapass_slot *slot = &__visapasses[i];
+            if (slot->type == type &&
+                slot->addr[0] == *addr)
+            {
+                found = slot;
+                break;
+            }
+        }
+    }
+    else
+    {
+        for (int i = 0; i < __visapass_filled_boundry; i++)
+        {
+            struct __visapass_slot *slot = &__visapasses[i];
+            if (slot->type == type &&
+                slot->addr[0] == addr[0] &&
+                slot->addr[1] == addr[1] &&
+                slot->addr[2] == addr[2] &&
+                slot->addr[3] == addr[3])
+            {
+                found = slot;
+                break;
+            }
+        }
+    }
+
+    // If the slot we found has expired, clean it up.
+    if (found && found->expire <= time(NULL))
+    {
+        found->type = 0; // Mark the slot as vacant.
+        found = NULL;
+    }
+
+    return found;
+}
+
+// Public interface-------------------------
+
+/**
+ * @return 0 if success. -1 if failure (due to all slots being filled).
+ */
+int visapass_add(const uint32_t *addr, const uint32_t ttl_sec, const bool ipv4)
+{
+    const uint8_t type = (ipv4 ? __IP_V4 : __IP_V6);
+
+    // Check if already exists.
+    struct __visapass_slot *slot = __visapass_find(addr, type);
+    if (!slot) // If not existing, find first vacant slot.
+    {
+        for (int i = 0; i < __VISAPASS_SLOT_COUNT; i++)
+        {
+            if (__visapasses[i].type == 0)
+            {
+                slot = &__visapasses[i];
+                if (__visapass_filled_boundry < i + 1)
+                    __visapass_filled_boundry = i + 1;
+                break;
+            }
+        }
+    }
+
+    if (slot)
+    {
+        slot->type = type;
+        slot->expire = time(NULL) + ttl_sec;
+
+        if (type == __IP_V4)
+        {
+            slot->addr[0] = *addr;
+        }
+        else
+        {
+            slot->addr[0] = addr[0];
+            slot->addr[1] = addr[1];
+            slot->addr[2] = addr[2];
+            slot->addr[3] = addr[3];
+        }
+
+        return 0;
+    }
+
+    return -1;
+}
+
+void visapass_remove(const uint32_t *addr, const bool ipv4)
+{
+    struct __visapass_slot *slot = __visapass_find(addr, (ipv4 ? __IP_V4 : __IP_V6));
+    if (slot)
+        slot->type = 0;
+}
+
+bool visapass_is_passed(const uint32_t *addr, const bool ipv4)
+{
+    return __visapass_find(addr, (ipv4 ? __IP_V4 : __IP_V6)) != NULL;
+}
+
+#endif


### PR DESCRIPTION
- UDP socket for visa check
- Ability to skip visa check
- IPv6 and IPv4 flags for server and client
  - Server -> Run and IPv6
  - Client -> Only connect to IPv4 servers
- Visa message protocol
  - `<version(uint16_t)><type(uint8_t)><payload>`
- Each client is identified by a identifier `hash(<ip><challenge>)`
- Messages
  - UDP
    - client -> server (Connect request `<init>`)
    - server -> client (Challenge `<challenge>`)
    - client -> server (Visa request `<challenge><pow>`)
    - server -> client (Approval `<approve|reject>`)
  - TCP
    - client -> server (Challenge `<challenge>`)